### PR TITLE
Implement in memory database for repo mock

### DIFF
--- a/src/UE/Tests/Application/ApplicationTestSuite.cpp
+++ b/src/UE/Tests/Application/ApplicationTestSuite.cpp
@@ -104,16 +104,23 @@ struct ApplicationConnectedTestSuite : ApplicationConnectingTestSuite
     }
 
     void showSmsListView(std::vector<SmsEntity>);
+    void recieveSms(std::string);
 };
 
 void ApplicationConnectedTestSuite::showSmsListView(std::vector<SmsEntity> testSmsVector)
 {
-    ON_CALL(smsRepositoryMock, getAll()).WillByDefault(Return(testSmsVector));
-
     EXPECT_CALL(smsRepositoryMock, getAll());
     EXPECT_CALL(userPortMock, showSmsList(testSmsVector));
 
     objectUnderTest.viewSmsList();
+}
+
+void ApplicationConnectedTestSuite::recieveSms(std::string text)
+{
+    EXPECT_CALL(userPortMock,showNewSms());
+    EXPECT_CALL(smsRepositoryMock,save(_));
+
+    objectUnderTest.handleSms(TEST_SENDER_NUMBER, text);
 }
 
 TEST_F(ApplicationConnectedTestSuite, shallDisConnectOnDisConnect)
@@ -124,41 +131,34 @@ TEST_F(ApplicationConnectedTestSuite, shallDisConnectOnDisConnect)
 
 TEST_F(ApplicationConnectedTestSuite, shallUserReceiveNotification)
 {
-    EXPECT_CALL(userPortMock,showNewSms());
-    EXPECT_CALL(smsRepositoryMock,save(_));
-    objectUnderTest.handleSms(TEST_SENDER_NUMBER,"Hello World!");
+    recieveSms("Hello World!");
 }
 
 struct ApplicationSmsListViewTestSuite : ApplicationConnectedTestSuite
 {
-    void showPopulatedSmsList();
+    ApplicationSmsListViewTestSuite(){
+        testSmsVector.push_back({TEST_SENDER_NUMBER.value, PHONE_NUMBER.value, "test1", true});
+        testSmsVector.push_back({PHONE_NUMBER.value, TEST_SENDER_NUMBER.value, "test2", true});
+        testSmsVector.push_back({TEST_SENDER_NUMBER.value, PHONE_NUMBER.value, "test3"});
+
+        smsRepositoryMock.database = testSmsVector;
+    }
     std::vector<SmsEntity> testSmsVector;
 };
 
-void ApplicationSmsListViewTestSuite::showPopulatedSmsList(){
-    testSmsVector.push_back({TEST_SENDER_NUMBER.value, PHONE_NUMBER.value, "test1", true});
-    testSmsVector.push_back({PHONE_NUMBER.value, TEST_SENDER_NUMBER.value, "test2", true});
-    testSmsVector.push_back({TEST_SENDER_NUMBER.value, PHONE_NUMBER.value, "test3"});
-
-    showSmsListView(testSmsVector);
-}
-
 TEST_F(ApplicationSmsListViewTestSuite, shallUserSeePopulatedSmsList)
 {
-    showPopulatedSmsList();
+    showSmsListView(testSmsVector);
 }
 
 TEST_F(ApplicationSmsListViewTestSuite, shallUserSeeEmptyList)
 {
-    showSmsListView(testSmsVector);
+    std::vector<SmsEntity> emptyList;
+    smsRepositoryMock.database.clear();
+    showSmsListView(emptyList);
 }
 
-struct ApplicationSmsViewTestSuite : ApplicationSmsListViewTestSuite
-{
-    ApplicationSmsViewTestSuite(){
-        showPopulatedSmsList();
-    }
-};
+struct ApplicationSmsViewTestSuite : ApplicationSmsListViewTestSuite {};
 
 TEST_F(ApplicationSmsViewTestSuite, shallUserReadSeenSmsAndExit)
 {
@@ -189,9 +189,12 @@ TEST_F(ApplicationSmsViewTestSuite, shallUserReadMultipleSmsAndExit)
 
     showSmsListView(testSmsVector);
 
-    EXPECT_CALL(userPortMock, showSms(testSmsVector[1]));
+    EXPECT_CALL(userPortMock, showSms(testSmsVector[2]));
+    EXPECT_CALL(smsRepositoryMock, saveAll(_, true));
     EXPECT_CALL(smsRepositoryMock, getAll());
-    objectUnderTest.viewSms(1);
+    objectUnderTest.viewSms(2);
+
+    testSmsVector[2].isRead = true;
 
     showSmsListView(testSmsVector);
 }

--- a/src/UE/Tests/Application/Mocks/ISmsRepositoryMock.cpp
+++ b/src/UE/Tests/Application/Mocks/ISmsRepositoryMock.cpp
@@ -3,7 +3,23 @@
 namespace ue
 {
 
-ISmsRepositoryMock::ISmsRepositoryMock() = default;
+ISmsRepositoryMock::ISmsRepositoryMock(){
+    ON_CALL(*this, save).WillByDefault([this](SmsEntity sms) {
+        database.push_back(sms);
+    });
+
+    ON_CALL(*this, getAll).WillByDefault([this]() {
+        return database;
+    });
+
+    ON_CALL(*this, saveAll).WillByDefault([this](const std::vector<SmsEntity>& smsVector, bool clearDb) {
+        if (clearDb)
+            database.clear();
+
+        for (auto &sms : smsVector)
+            database.push_back(sms);
+    });
+}
 ISmsRepositoryMock::~ISmsRepositoryMock() = default;
 
 }

--- a/src/UE/Tests/Application/Mocks/ISmsRepositoryMock.h
+++ b/src/UE/Tests/Application/Mocks/ISmsRepositoryMock.h
@@ -19,6 +19,8 @@ public:
     MOCK_METHOD(void, save, (const SmsEntity&), (final));
     MOCK_METHOD(std::vector<SmsEntity>, getAll, (), (final));
     MOCK_METHOD(void, saveAll, (const std::vector<SmsEntity>&, bool ), (final));
+
+    std::vector<SmsEntity> database;
 };
 }
 

--- a/src/UE/Tests/Application/Ports/UserPortTestSuite.cpp
+++ b/src/UE/Tests/Application/Ports/UserPortTestSuite.cpp
@@ -71,6 +71,7 @@ TEST_F(UserPortTestSuite, shallShowSmsList)
     EXPECT_CALL(guiMock, setListViewMode()).WillOnce(ReturnRef(listViewModeMock));
     EXPECT_CALL(listViewModeMock, clearSelectionList());
     EXPECT_CALL(listViewModeMock, addSelectionListItem(_, _)).Times(Exactly(3));
+    EXPECT_CALL(guiMock, showNewSms(false)).Times(Exactly(1));
     EXPECT_CALL(guiMock, setAcceptCallback(_)).Times(Exactly(1));
     EXPECT_CALL(guiMock, setRejectCallback(_)).Times(Exactly(1));
 


### PR DESCRIPTION
Used macro 'ON_CALL' inside a mock in order to simulate in-memory database